### PR TITLE
Fix Broken Open Image in Gmail

### DIFF
--- a/lib/ahoy_email/processor.rb
+++ b/lib/ahoy_email/processor.rb
@@ -82,7 +82,7 @@ module AhoyEmail
             id: ahoy_message.token,
             format: "gif"
           )
-        pixel = ActionController::Base.helpers.image_tag(url, size: "1x1", alt: nil)
+        pixel = ActionController::Base.helpers.image_tag(url, height: 1, width: 1, border: 0, alt: nil)
 
         # try to add before body tag
         if raw_source.match(regex)


### PR DESCRIPTION
Use height, width and border instead of size for the open image tag. The current method results in a broken image in Gmail.

Note: Gmail appears to be caching the image, but the open_at is updated.
