### PR TITLE
Fix utm tracking on unsubscribe

### DIFF
--- a/lib/ahoy_email/processor.rb
+++ b/lib/ahoy_email/processor.rb
@@ -139,9 +139,6 @@ module AhoyEmail
         # remove it
         link.remove_attribute(attribute)
         true
-      elsif link["href"].to_s =~ /unsubscribe/i
-        # try to avoid unsubscribe links
-        true
       else
         false
       end


### PR DESCRIPTION
skip_attribute? should not automatically skip unsubscribe links. It is helpful to be able to track which emails result in unsubscribes using utm tags.  Besides, the gem api provides the ability to manually skip utm tags on unsubscribe links through the track utm_params data attribute.
